### PR TITLE
Continue reducing animation-editor.tx

### DIFF
--- a/components/editor/LayersPanel.tsx
+++ b/components/editor/LayersPanel.tsx
@@ -64,6 +64,7 @@ export default function LayersPanel(props: LayersPanelProps) {
     setLayerOpacities,
     folderLayers,
     layerOrder,
+    layerVisibility,
     moveLayer,
     moveFrameFolderUp,
     moveFrameFolderDown,

--- a/components/editor/TimelineControls.tsx
+++ b/components/editor/TimelineControls.tsx
@@ -24,7 +24,7 @@ export default function TimelineControls({ zoom, setZoom, isPlaying, onPlayPause
       <Button variant="outline" size="sm" className="text-gray-400 bg-transparent border-gray-600" onClick={() => setZoom((prev) => Math.min(3, prev + 0.1))}>
         <ZoomIn className="w-4 h-4" />
       </Button>
-      <Button variant="outline" size="sm" className="text-gray-400 bg-transparent border-gray-600" onClick={() => setZoom(1)}>
+      <Button variant="outline" size="sm" className="text-gray-400 bg-transparent border-gray-600" onClick={() => setZoom(() => 1)}>
         <RotateCcw className="w-4 h-4" />
       </Button>
       <div className="ml-4 flex items-center gap-2">

--- a/components/project-detail.tsx
+++ b/components/project-detail.tsx
@@ -482,7 +482,7 @@ export function ProjectDetail({ onViewChange, projectId }: ProjectDetailProps) {
                 err = inRes.error;
                 try {
                   const orExpr = chapterIds
-                    .map((id) => `chapter_id.eq.${id}`)
+                    .map((id: string) => `chapter_id.eq.${id}`)
                     .join(",");
                   const orRes = await supabase
                     .from("animated_chapters")

--- a/hooks/useCanvasInteractions.ts
+++ b/hooks/useCanvasInteractions.ts
@@ -261,7 +261,7 @@ export default function useCanvasInteractions(args: UseCanvasInteractionsArgs) {
           setLayerStrokes((prev) => {
             const other =
               prev[selectedLayerId]?.filter(
-                (s) => !movedStrokes.some((ms) => ms.id === s.id)
+                (s) => !movedStrokes.some((ms: DrawingStroke) => ms.id === s.id)
               ) || [];
             return { ...prev, [selectedLayerId]: [...other, ...movedStrokes] };
           });

--- a/hooks/useSelectionTools.ts
+++ b/hooks/useSelectionTools.ts
@@ -9,6 +9,8 @@ export interface DrawingStroke {
   points: Point[];
 }
 
+import { useRef, useState } from "react";
+
 export default function useSelectionTools() {
   const [lassoSelection, setLassoSelection] = useState<{
     points: Point[];

--- a/lib/editor/geometry.ts
+++ b/lib/editor/geometry.ts
@@ -67,3 +67,20 @@ export function getResizeHandles(box: any) {
     },
   } as const;
 }
+
+export function getLassoBoundingBox(points: Point[]) {
+  if (!Array.isArray(points) || points.length === 0) {
+    return { minX: 0, maxX: 0, minY: 0, maxY: 0 };
+  }
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity;
+  for (const p of points) {
+    minX = Math.min(minX, p.x);
+    maxX = Math.max(maxX, p.x);
+    minY = Math.min(minY, p.y);
+    maxY = Math.max(maxY, p.y);
+  }
+  return { minX, maxX, minY, maxY };
+}

--- a/lib/editor/persistence.ts
+++ b/lib/editor/persistence.ts
@@ -12,7 +12,7 @@ export interface SerializeDocArgs {
   layerOrder: Record<string, string[]>;
   folderLayers: Record<string, string[]>;
   layerStrokes: Record<string, any[]>;
-  currentFrame: number;
+  currentFrame?: number;
   selectedRow: string;
   zoom: number;
   onionSkin: boolean;
@@ -48,7 +48,7 @@ export function serializeDocument(args: SerializeDocArgs) {
     frameCount,
     timeline: { drawingFrames, layerOrder },
     layers: { folderLayers, layerStrokes },
-    uiState: { currentFrame, selectedRow, zoom, onionSkin, showGrid },
+    uiState: { currentFrame: currentFrame ?? 1, selectedRow, zoom, onionSkin, showGrid },
     frameAssetKeys,
     folderNames,
   } as const;


### PR DESCRIPTION
Refactor `animation-editor.tsx` to reduce its size and complexity by removing legacy frame management and inlined canvas interaction logic.

The `animation-editor.tsx` file was overly large and contained redundant logic for frame management and canvas interactions. This PR extracts common utilities, leverages existing hooks (`useCanvasInteractions`, `useSelectionTools`), and removes deprecated `currentFrame` state and associated CRUD operations, streamlining the editor's core logic. This improves maintainability and readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b707b50-debc-4307-a1a8-70624f749c17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b707b50-debc-4307-a1a8-70624f749c17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

